### PR TITLE
5 rich input element traversal

### DIFF
--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -176,7 +176,7 @@ function exprLib(list, tree, parse) {
 			symbol:     symbol,
 			fixity:     fixity
 
-			traversal:   traversalOrder,	
+			traversal:   traversalOrder
 		}),
 
 		render: Object.freeze({

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -175,6 +175,8 @@ function exprLib(list, tree, parse) {
 			value:      value,
 			symbol:     symbol,
 			fixity:     fixity
+
+			traversal:   traversalOrder,	
 		}),
 
 		render: Object.freeze({
@@ -198,8 +200,6 @@ function exprLib(list, tree, parse) {
 
 		matchType:   matchType,
 		matchFixity: matchFixity,
-
-		traversal:   traversalOrder,	
 		
 		number:     number,
 		num:        number,

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -45,7 +45,7 @@ function exprLib(pair, list, tree, parse) {
 	const div  = (x, y) => binaryOp('/', infix, x, y);
 	const exp  = (x, y) => binaryOp('^', infix, x, y);
 
-	const placeholder = voidOp('Placeholder', prefix);
+	const placeholder = () => voidOp('Placeholder', prefix);
 
 
 // Accessors
@@ -165,18 +165,11 @@ function exprLib(pair, list, tree, parse) {
 
 
 // Labeling
-	const positionLabel = pos => Object.freeze({
-		__proto__: null,
-
-		name:  'pos',
-		value: pos
-	});
-
 	const labelPosition = e => list.foldr(
 		tree.labels.create(e), 
 		(p, t) => pair.match(p)(
 			(pos, value) => 
-				tree.labels.add(positionLabel(pos), value)(t)
+				tree.labels.add(tree.labels.build('pos', pos), value)(t)
 		)
 	)(list.index(traversalOrder(e)));
 

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -137,14 +137,14 @@ function exprLib(pair, list, tree, parse) {
 
 
 // Traversal
+	const skipLabel = tree.labels.build('skip', null);
+
 	const traversalOrder = tree.foldr(
 		taggedEv  => list.produce(taggedEv),
 		(taggedEv, css) => {
 			const cs = list.join(css);
 
-			const dontTraverse = tag => 
-				tag.name  === 'traverse' && 
-				tag.value === false;
+			const dontTraverse = tag => tag === skipLabel;
 
 			const skip = list.contains(dontTraverse, tree.labels.getLabels(taggedEv))
 
@@ -212,6 +212,8 @@ function exprLib(pair, list, tree, parse) {
 
 		label: Object.freeze({
 			__proto__: null,
+
+			skip: skipLabel,
 
 			pos: labelPosition
 		}),

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -174,7 +174,7 @@ function exprLib(list, tree, parse) {
 			type:       type,
 			value:      value,
 			symbol:     symbol,
-			fixity:     fixity
+			fixity:     fixity,
 
 			traversal:   traversalOrder
 		}),

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -138,40 +138,54 @@ function exprLib(pair, list, tree, parse) {
 
 // Traversal
 	const traversalOrder = tree.foldr(
-		ev       => list.produce(ev),
-		(ev, css) => {
+		taggedEv  => list.produce(taggedEv),
+		(taggedEv, css) => {
 			const cs = list.join(css);
 
-			return matchType(ev)(
+			const dontTraverse = tag => 
+				tag.name  === 'traverse' && 
+				tag.value === false;
+
+			const skip = list.contains(dontTraverse, tree.labels.getLabels(taggedEv))
+
+			return matchType(tree.labels.getValue(taggedEv))(
 				// Leaves don't need definitions
 				number   => undefined,
 				variable => undefined,
 				voidOp   => undefined,
 
 				// Branches
-				unaryOp  => matchFixity(unaryOp)(
-					prefix  => list.cons(ev, cs), 
-					infix   => undefined,
-					postfix => list.append(ev, cs) 
-				),
-				binaryOp => matchFixity(binaryOp)(
-					prefix  => list.cons(ev, cs),
-					infix   => list.concat(list.head(css), list.cons(ev, list.join(list.tail(css)))),
-					postfix => list.append(ev, cs)
-				)
-			)
+				unaryOp  => 
+					(skip ? cs :
+						matchFixity(unaryOp)(
+							prefix  => list.cons(taggedEv, cs), 
+							infix   => undefined,
+							postfix => list.append(taggedEv, cs) 
+						)),
+				binaryOp => 
+					(skip ? cs :
+						matchFixity(binaryOp)(
+							prefix  => list.cons(taggedEv, cs),
+							infix   => list.concat(list.head(css), list.cons(taggedEv, list.join(list.tail(css)))),
+							postfix => list.append(taggedEv, cs)
+						))
+			);
 		}
 	);
 
 
 // Labeling
-	const labelPosition = e => list.foldr(
-		tree.labels.create(e), 
-		(p, t) => pair.match(p)(
-			(pos, value) => 
-				tree.labels.add(tree.labels.build('pos', pos), value)(t)
+	const labelPosition = labeledExpr => list.foldr(
+		labeledExpr, 
+		(itemPair, result) => 
+			pair.match(itemPair)(
+				(pos, taggedEv) => 
+					tree.labels.add(
+						tree.labels.build('pos', pos), 
+						tree.labels.getValue(taggedEv)
+					)(result)
 		)
-	)(list.index(traversalOrder(e)));
+	)(list.index(traversalOrder(labeledExpr)));
 
 
 // Library

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -96,6 +96,14 @@ function exprLib(list, tree, parse) {
 			}
 		};
 
+	const isOperator = ev => matchType(ev)(
+		number   => false, 
+		variable => false, 
+		voidOp   => true, 
+		unaryOp  => true,
+		binaryOp => true
+	);
+
 	const matchFixity = op => (onPrefix, onInfix, onPostfix) => {
 		switch(op.fixity) {
 			case prefix:
@@ -109,13 +117,72 @@ function exprLib(list, tree, parse) {
 		}
 	};
 
+
+// Rendering
+	const header = ev => matchType(ev)(
+		number   => 'num: ' + number.toString(),
+		variable => 'var: ' + variable,
+		voidOp   => fixity(voidOp)   + ' op(0): ' + symbol(voidOp),
+		unaryOp  => fixity(unaryOp)  + ' op(1): ' + symbol(unaryOp),
+		binaryOp => fixity(binaryOp) + ' op(2): ' + symbol(binaryOp)
+	);
+
+	const asString = ev => matchType(ev)(
+		number   => number.toString(),
+		variable => variable,
+		voidOp   => symbol(voidOp),
+		unaryOp  => symbol(unaryOp),
+		binaryOp => symbol(binaryOp)
+	);
+
+
+// Traversal
+	const traversalOrder = tree.foldr(
+		ev       => list.produce(ev),
+		(ev, css) => {
+			const cs = list.join(css);
+
+			return matchType(ev)(
+				// Leaves don't need definitions
+				number   => undefined,
+				variable => undefined,
+				voidOp   => undefined,
+
+				// Branches
+				unaryOp  => matchFixity(unaryOp)(
+					prefix  => list.cons(ev, cs), 
+					infix   => undefined,
+					postfix => list.append(ev, cs) 
+				),
+				binaryOp => matchFixity(binaryOp)(
+					prefix  => list.cons(ev, cs),
+					infix   => list.concat(list.head(css), list.cons(ev, list.join(list.tail(css)))),
+					postfix => list.append(ev, cs)
+				)
+			)
+		}
+	);
+
+
+// Library
 	return Object.freeze({
 		__proto__: null,
 
-		type:       type,
-		value:      value,
-		symbol:     symbol,
-		fixity:     fixity,
+		get: Object.freeze({
+			__proto__: null,
+
+			type:       type,
+			value:      value,
+			symbol:     symbol,
+			fixity:     fixity
+		}),
+
+		render: Object.freeze({
+			__proto__: null,
+
+			header:     header,
+			asString:   asString
+		}),	
 
 		prefix:     prefix,
 		infix:      infix,
@@ -124,12 +191,16 @@ function exprLib(list, tree, parse) {
 		voidOp:     voidOp,
 		unaryOp:    unaryOp,
 		binaryOp:   binaryOp,
+		isOperator: isOperator,
+		isOp:       isOperator,
 
 		lookupOp:   lookupOp,
 
 		matchType:   matchType,
 		matchFixity: matchFixity,
 
+		traversal:   traversalOrder,	
+		
 		number:     number,
 		num:        number,
 		

--- a/scripts/expr.js
+++ b/scripts/expr.js
@@ -1,5 +1,5 @@
 
-function exprLib(list, tree, parse) {
+function exprLib(pair, list, tree, parse) {
 
 // Expression Values
 	const exprValue = (type, value) => Object.freeze({
@@ -164,6 +164,23 @@ function exprLib(list, tree, parse) {
 	);
 
 
+// Labeling
+	const positionLabel = pos => Object.freeze({
+		__proto__: null,
+
+		name:  'pos',
+		value: pos
+	});
+
+	const labelPosition = e => list.foldr(
+		tree.labels.create(e), 
+		(p, t) => pair.match(p)(
+			(pos, value) => 
+				tree.labels.add(positionLabel(pos), value)(t)
+		)
+	)(list.index(traversalOrder(e)));
+
+
 // Library
 	return Object.freeze({
 		__proto__: null,
@@ -185,6 +202,12 @@ function exprLib(list, tree, parse) {
 			header:     header,
 			asString:   asString
 		}),	
+
+		label: Object.freeze({
+			__proto__: null,
+
+			pos: labelPosition
+		}),
 
 		prefix:     prefix,
 		infix:      infix,

--- a/scripts/list.js
+++ b/scripts/list.js
@@ -53,6 +53,15 @@ function listLib(pair) {
 
 	const length = foldr(0, (_, n) => n + 1);
 
+	const generate = (seed, f, n) => {
+		switch(n) {
+			case 0:
+				return empty;
+			default:
+				return cons(seed, fmap(f)(generate(seed, f, n - 1)));
+		}
+	};
+
 
 // Conversions
 	const from  = arr => arr.reduceRight((as, a) => cons(a, as), empty);
@@ -96,7 +105,9 @@ function listLib(pair) {
 			undefined, 
 			(x, r) => 
 				pair.fst(x) === field ? pair.snd(x) : r
-		)(dict); 
+		)(dict);
+
+	const index = xs => zip(generate(0, x => x + 1, length(xs)), xs);
 
 
 // Library
@@ -127,6 +138,8 @@ function listLib(pair) {
 		concat:     concat,
 		reverse:    reverse,
 
+		generate:   generate,
+
 		produce:  produce,
 		join:     join,
 		bind:     bind,
@@ -141,6 +154,7 @@ function listLib(pair) {
 		build:   list,
 
 		zip:     zip,
-		lookup:  lookup
+		lookup:  lookup,
+		index:   index
 	});
 }

--- a/scripts/list.js
+++ b/scripts/list.js
@@ -118,6 +118,9 @@ function listLib(pair) {
 	const index = xs => zip(generate(0, x => x + 1, length(xs)), xs);
 
 
+// Aux
+	const contains = (condx, xs) => !isEmpty(filter(condx, xs));
+
 // Library
 	return Object.freeze({
 		__proto__: null,
@@ -168,6 +171,8 @@ function listLib(pair) {
 
 		zip:     zip,
 		lookup:  lookup,
-		index:   index
+		index:   index,
+
+		contains: contains
 	});
 }

--- a/scripts/list.js
+++ b/scripts/list.js
@@ -62,6 +62,10 @@ function listLib(pair) {
 		}
 	};
 
+	const drop = n => xs => n === 0 ? xs : drop(n - 1)(tail(xs));
+
+	const at = (n, xs) => head(drop(n)(xs));
+
 
 // Conversions
 	const from  = arr => arr.reduceRight((as, a) => cons(a, as), empty);
@@ -130,6 +134,9 @@ function listLib(pair) {
 
 		length:  length,
 		len:     length,
+
+		drop:    drop,
+		at:      at,
 
 		foldr:      foldr,
 		foldl:      foldl,

--- a/scripts/list.js
+++ b/scripts/list.js
@@ -66,6 +66,10 @@ function listLib(pair) {
 
 	const at = (n, xs) => head(drop(n)(xs));
 
+	const take = n => xs => n === 0 ? empty : cons(head(xs), take(n - 1)(tail(xs)));
+
+	const insert = (n, x, xs) => concat(take(n)(xs), cons(x, drop(n)(xs)));
+
 
 // Conversions
 	const from  = arr => arr.reduceRight((as, a) => cons(a, as), empty);
@@ -131,11 +135,13 @@ function listLib(pair) {
 
 		cons:    cons,
 		append:  append,
+		insert:  insert,
 
 		length:  length,
 		len:     length,
 
 		drop:    drop,
+		take:    take,
 		at:      at,
 
 		foldr:      foldr,

--- a/scripts/markup.js
+++ b/scripts/markup.js
@@ -21,6 +21,12 @@ function markupLib(pair, list, tree, parse) {
 		};
 	};
 
+	const tag        = e => e.tag;
+	const closed     = e => e.closed;
+	const attributes = e => e.attributes;
+
+	const rawText = e => list.head(e.attributes).value;
+
 	const text = str => element('text:', true, list.build(attribute('value', str)));
 
 
@@ -60,31 +66,31 @@ function markupLib(pair, list, tree, parse) {
 // Parsing Element Trees
 	const parseJSString = parse.tryAll(
 		list.build(
-			parse.singleQuote, 
-			parse.doubleQuote)
+			parse.str.singleQuote, 
+			parse.str.doubleQuote)
 	);
 
 	const parseAttribute = parse.bind(
-		parse.aWord,
+		parse.str.aWord,
 		name => parse.seq(
-			parse.aChar('='),
+			parse.str.aChar('='),
 			parse.bind(
 				parseJSString,
 				value => parse.produce(attribute(name, value)))));
 
 	const parseTagAttributes = parse.bind(
-		parse.aWord,
+		parse.str.aWord,
 		tag => parse.bind(
-			parse.many(parse.seq(parse.aChar(' '), parseAttribute)),
+			parse.many(parse.seq(parse.str.aChar(' '), parseAttribute)),
 			as => parse.produce(pair.build(tag, as))
 		)
 	);
 
-	const parseOpeningTag = parse.between(parse.aChar('<'), parseTagAttributes, parse.aChar('>'));
+	const parseOpeningTag = parse.between(parse.str.aChar('<'), parseTagAttributes, parse.str.aChar('>'));
 
-	const parseClosingTag = parse.between(parse.aString('</'), parse.aWord, parse.aChar('>'));
+	const parseClosingTag = parse.between(parse.str.aString('</'), parse.str.aWord, parse.str.aChar('>'));
 
-	const parseSelfClosingTag = parse.between(parse.aChar('<'), parseTagAttributes, parse.aString('/>'));
+	const parseSelfClosingTag = parse.between(parse.str.aChar('<'), parseTagAttributes, parse.str.aString('/>'));
 
 	const parseText = parse.bind(
 		// Parse any characters that are not part of an opening or closing tag
@@ -94,7 +100,7 @@ function markupLib(pair, list, tree, parse) {
 					parse.seq(
 						parse.tryAll(list.build(parseOpeningTag, parseClosingTag)), 
 						parse.produce('')),
-					_ => parse.anyChar
+					_ => parse.str.anyChar
 				),
 				s => s.length === 0 ? parse.fail : parse.produce(s))),
 		// Wrap those characters in a 'text:' node.
@@ -134,7 +140,7 @@ function markupLib(pair, list, tree, parse) {
 
 	const fix = (f) => parse.bind(
 		parse.produce(g => g(fix(g))),
-		q => q(f)		
+		q => q(f)
 	);
 
 	const parseTree = parseNormalElement(
@@ -158,6 +164,11 @@ function markupLib(pair, list, tree, parse) {
 		attr:       attribute,
 		element:    element,
 		el:         element,
+
+		tag:        tag,
+		closed:     closed,
+		attributes: attributes,
+		rawText:    rawText,
 
 		text:       text,
 

--- a/scripts/mathML.js
+++ b/scripts/mathML.js
@@ -1,6 +1,7 @@
 
 function mathMLLib(list, tree, expr, markup, parse) {
 
+// Markup Generation
 	const textContainer = (tag, attributes, txt) => 
 		tree.node(
 			markup.el(tag, false, attributes), 
@@ -11,7 +12,7 @@ function mathMLLib(list, tree, expr, markup, parse) {
 		n   => textContainer('mn', list.nil, n), 
 		v   => textContainer('mi', list.nil, v),
 		vop => {
-			if (expr.symbol(vop) === 'Placeholder')
+			if (expr.get.symbol(vop) === 'Placeholder')
 				return textContainer(
 					'span', 
 					list.build(
@@ -22,10 +23,10 @@ function mathMLLib(list, tree, expr, markup, parse) {
 					),
 					'&nbsp;');
 			else
-				return textContainer('mo', list.nil, expr.symbol(vop))
+				return textContainer('mo', list.nil, expr.get.symbol(vop))
 		},
-		uop => textContainer('mo', list.nil, expr.symbol(uop)),
-		bop => textContainer('mo', list.nil, expr.symbol(bop))
+		uop => textContainer('mo', list.nil, expr.get.symbol(uop)),
+		bop => textContainer('mo', list.nil, expr.get.symbol(bop))
 	);
 
 	const markupExprTree = tree.foldr(
@@ -33,12 +34,12 @@ function mathMLLib(list, tree, expr, markup, parse) {
 		(v, cs) => {
 			const op = v.value;
 
-			if (expr.fixity(op) === expr.infix &&
-				(expr.symbol(op) === '/') ||
-				(expr.symbol(op) === '^'))
+			if (expr.get.fixity(op) === expr.infix &&
+				(expr.get.symbol(op) === '/') ||
+				(expr.get.symbol(op) === '^'))
 
 				return tree.node(
-					markup.el(expr.symbol(op) === '/' ? 'mfrac' : 'msup', false, list.nil),
+					markup.el(expr.get.symbol(op) === '/' ? 'mfrac' : 'msup', false, list.nil),
 					cs);
 			else
 				return tree.node(
@@ -52,6 +53,8 @@ function mathMLLib(list, tree, expr, markup, parse) {
 		}
 	);
 
+
+// Library
 	return Object.freeze({
 		__proto__: null,
 

--- a/scripts/mathML.js
+++ b/scripts/mathML.js
@@ -1,5 +1,5 @@
 
-function mathMLLib(list, tree, expr, markup, parse) {
+function mathMLLib(pair, list, tree, expr, markup, parse) {
 
 // Markup Generation
 	const textContainer = (tag, attributes, txt) => 
@@ -8,46 +8,51 @@ function mathMLLib(list, tree, expr, markup, parse) {
 			list.build(tree.leaf(markup.text(txt)))
 		);
 
-	const markupExpr = ev => expr.matchType(ev)(
-		n   => textContainer('mn', list.nil, n), 
-		v   => textContainer('mi', list.nil, v),
+	const processTags = list.fmap(tag => markup.attr(tag.name, tag.value));
+
+	const markupExpr = (ev, tags) => expr.matchType(ev)(
+		n   => textContainer('mn', processTags(tags), n), 
+		v   => textContainer('mi', processTags(tags), v),
 		vop => {
 			if (expr.get.symbol(vop) === 'Placeholder')
 				return textContainer(
 					'span', 
-					list.build(
+					list.cons(
 						markup.attr(
 							'class',
 							'placeholder'
-						)
+						),
+						processTags(tags)
 					),
 					'&nbsp;');
 			else
-				return textContainer('mo', list.nil, expr.get.symbol(vop))
+				return textContainer('mo', processTags(tags), expr.get.symbol(vop))
 		},
-		uop => textContainer('mo', list.nil, expr.get.symbol(uop)),
-		bop => textContainer('mo', list.nil, expr.get.symbol(bop))
+		uop => textContainer('mo', processTags(tags), expr.get.symbol(uop)),
+		bop => textContainer('mo', processTags(tags), expr.get.symbol(bop))
 	);
 
 	const markupExprTree = tree.foldr(
-		markupExpr,
+		p => pair.match(p)((ev, tags) => markupExpr(ev, tags)),
 		(v, cs) => {
-			const op = v.value;
+			const tags = tree.labels.getLabels(v);
+			const ev = tree.labels.getValue(v);
+			const op = ev.value;
 
 			if (expr.get.fixity(op) === expr.infix &&
 				(expr.get.symbol(op) === '/') ||
 				(expr.get.symbol(op) === '^'))
 
 				return tree.node(
-					markup.el(expr.get.symbol(op) === '/' ? 'mfrac' : 'msup', false, list.nil),
+					markup.el(expr.get.symbol(op) === '/' ? 'mfrac' : 'msup', false, processTags(tags)),
 					cs);
 			else
 				return tree.node(
 					markup.el('mrow', false, list.nil),
-					expr.matchFixity(v.value)(
-						prefixOp  => list.cons(markupExpr(v), cs),
-						infixOp   => list.cons(list.head(cs), list.cons(markupExpr(v), list.tail(cs))),
-						postfixOp => list.append(markupExpr(v), cs)
+					expr.matchFixity(op)(
+						prefixOp  => list.cons(markupExpr(ev, tags), cs),
+						infixOp   => list.cons(list.head(cs), list.cons(markupExpr(ev, tags), list.tail(cs))),
+						postfixOp => list.append(markupExpr(ev, tags), cs)
 					)
 				);
 		}
@@ -58,6 +63,6 @@ function mathMLLib(list, tree, expr, markup, parse) {
 	return Object.freeze({
 		__proto__: null,
 
-		markupExprTree: markupExprTree
+		markupLabeledExprTree: markupExprTree
 	})
 }

--- a/scripts/mathML.js
+++ b/scripts/mathML.js
@@ -16,7 +16,7 @@ function mathMLLib(pair, list, tree, expr, markup, parse) {
 		vop => {
 			if (expr.get.symbol(vop) === 'Placeholder')
 				return textContainer(
-					'span', 
+					'div', 
 					list.cons(
 						markup.attr(
 							'class',

--- a/scripts/pair.js
+++ b/scripts/pair.js
@@ -23,6 +23,8 @@ function pairLib() {
 			(a, b) => pair(f(a), g(b))
 		);
 
+	const swap = p => match(p)((a, b) => pair.build(b, a));
+
 
 // Library
 	return Object.freeze({
@@ -37,6 +39,8 @@ function pairLib() {
 		second: snd,
 		snd:    snd,
 
-		fmap:   fmap
+		fmap:   fmap,
+
+		swap:   swap
 	});
 }

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -150,7 +150,7 @@ function parseLib(sum, sigma, list) {
 				return expected('an element');
 			else
 				return sequence(
-					setInput(pair.build(pos + 1, tail.list(xs))),
+					setInput(pair.build(pos + 1, list.tail(xs))),
 					produce(list.head(xs)));
 		}
 	);
@@ -312,7 +312,7 @@ function parseLib(sum, sigma, list) {
 		str: Object.freeze({
 			__proto__: null,
 
-			run:      run,
+			run:         runStr,
 			
 			anyChar:     anyChar,
 			character:   character,

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -87,7 +87,7 @@ function parseLib(sum, sigma, list) {
 	const satisfy = (condx, px) => 
 		bind(px, x => condx(x) ? 
 				produce(x) : 
-				failBecause(`the value '${x}' did not satisfy the condition '${condx.name}'`));
+				failBecause(`the value did not satisfy the condition`));
 
 	const exact = (x, px) => 
 		onFailureOf(
@@ -139,25 +139,29 @@ function parseLib(sum, sigma, list) {
 	);
 
 
+// List Parsing
+	const nextElement = bind(
+		getInput,
+		input => {
+			const pos = pair.fst(input);
+			const xs  = pair.snd(input);
+
+			if (list.isEmpty(xs))
+				return expected('an element');
+			else
+				return sequence(
+					setInput(pair.build(pos + 1, tail.list(xs))),
+					produce(list.head(xs)));
+		}
+	);
+	
+
 // String Parsing	
 	const runStr = (p, s) => p(pair.build(0, list.fromStr(s)));
 
 
 // Characters
-	const anyChar = bind(
-		getInput,
-		input => {
-			const pos = pair.fst(input);
-			const str = pair.snd(input);
-
-			if (list.isEmpty(str))
-				return expected('a character');
-			else
-				return sequence(
-					setInput(pair.build(pos + 1, list.tail(str))),
-					produce(list.head(str)));
-		}
-	);
+	const anyChar = onFailureOf(nextElement, _ => expected('a character'));
 
 	const character = c => exact(c, anyChar);
 
@@ -194,8 +198,7 @@ function parseLib(sum, sigma, list) {
 
 	const hexPositive = fmap(a => parseInt('0x' + toStr(a)))(many1(hexDigit));
 
-
-// Strings
+// Specific Strings
 	const aString = s => fmap(toStr)(traverse(list.fmap(character)(list.fromStr(s))));
 
 	const singleQuoted = bind(
@@ -220,6 +223,48 @@ function parseLib(sum, sigma, list) {
 	const aLetter = tryAll(list.build(lowercase, uppercase));
 
 	const aWord = bind(many1(aLetter), cs => produce(toStr(cs)));
+
+
+// Trees
+	const treeInput = sigma.create(list.build('empty', 'tree'));
+
+	const runTree = (p, t) => p(treeInput.inject('tree')(t));
+
+	const getValue = bind(
+		getInput,
+		mt => treeInput.match(mt)(list.build(
+			pair.build('empty', _ => expected('a tree')),
+			pair.build('tree',  t => produce(tree.value(t)))
+		))
+	);
+
+	const getChildren = bind(
+		getInput,
+		mt => treeInput.match(mt)(list.build(
+			pair.build('empty', _ => expected('a tree')),
+			pair.build('tree',  t => produce(tree.children(t)))
+		))
+	);
+
+	const parseLeaf = onFailureOf(
+		sequence(
+			satisfy(list.isEmpty, getChildren),
+			getValue
+		),
+		_ => expected('a leaf')
+	);
+
+	const parseNode = onFailureOf(
+		bind(getValue,
+			v => bind(getChildren,
+				cs => sequence(
+					list.isEmpty(cs) ? fail : produce({}),
+					produce(pair.build(v, cs))
+				)
+			)
+		),
+		_ => expected('a node')
+	);
 
 
 // Library
@@ -258,44 +303,61 @@ function parseLib(sum, sigma, list) {
 		many1:       many1,
 		repeat1:     many1,
 
-		runStr:      runStr,
-		
-		anyChar:     anyChar,
-		consume:     anyChar,
-		character:   character,
-		chr:         character,
-		aChar:       character,
-		oneOf:       oneOf,
+		list: Object.freeze({
+			__proto__: null,
 
-		digit:       digit,
-		aDigit:      digit,
-		positive:    positive,
-		aPositive:   positive,
-		natural:     positive,
-		aNatural:    positive,
-		negative:    negative,
-		aNegative:   negative,
-		integer:     integer,
-		anInteger:   integer,
-		aFloat:      aFloat,
-		decimal:     aFloat,
+			next:        nextElement,
+		}),
 
-		hexDigit:    hexDigit,
-		aHexDigit:   hexDigit,
-		hexPositive: hexPositive,
-		aHexPositive: hexPositive,
+		str: Object.freeze({
+			__proto__: null,
 
-		aString:     aString,
-		str:         aString,
-		singleQuote: singleQuoted,
-		doubleQuote: doubleQuoted,
+			run:      run,
+			
+			anyChar:     anyChar,
+			character:   character,
+			chr:         character,
+			aChar:       character,
+			oneOf:       oneOf,
 
-		lowercase:   lowercase,
-		uppercase:   uppercase,
-		letter:      aLetter,
-		aLetter:     aLetter,
-		aWord:       aWord,
-		word:        aWord
+			digit:       digit,
+			aDigit:      digit,
+			positive:    positive,
+			aPositive:   positive,
+			negative:    negative,
+			aNegative:   negative,
+			integer:     integer,
+			anInteger:   integer,
+			aFloat:      aFloat,
+
+			hexDigit:    hexDigit,
+			hexPositive: hexPositive,
+
+			aString:     aString,
+			str:         aString,
+			singleQuote: singleQuoted,
+			doubleQuote: doubleQuoted,
+
+			lowercase:   lowercase,
+			uppercase:   uppercase,
+			letter:      aLetter,
+			aLetter:     aLetter,
+			aWord:       aWord,
+			word:        aWord
+		}),
+
+		tree: Object.freeze({
+			__proto__: null,
+
+			run:      runTree,
+			input:    treeInput,
+
+			value:    getValue,
+			children: getChildren,
+
+			leaf:     parseLeaf,
+			node:     parseNode
+		})
 	});
 }
 

--- a/scripts/richMathInput.js
+++ b/scripts/richMathInput.js
@@ -58,13 +58,33 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 		);
 
 
+		
+		const nontraversable = list.build('^', '/');
+
+
+		// Lengths
+		const getExprLengths = () => {
+			return list.fmap(
+				t => list.length(
+					expr.get.traversal(tree.labels.addIf(
+						expr.label.skip,
+						ev => expr.isOp(ev) && 
+							list.contains(
+								x => x === ev.value.symbol,
+								nontraversable
+							)
+					)(tree.labels.create(t)))
+				)
+			)(state.current().exprs);
+		}
+
 
 		// Cursor Position
 		const updateCursorPos = () => {
 			const pos   = state.current().pos;
 			const exprs = state.current().exprs;
 			const len   = list.length(exprs);
-			const exprLengths = list.append(0, list.fmap(t => list.length(tree.polish(t)))(exprs));
+			const exprLengths = getExprLengths();
 
 			// Prepare the nodes
 			const allNodes = doc.querySelectorAll(`[pos]`);
@@ -72,36 +92,17 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 
 			if (allNodes.length === 0) return;
 
-			const tmp = doc.querySelectorAll(`[pos="${pos.treePos}"]`);
-			const nodeArray = [];
-
-			for (let i = 0; i < tmp.length; ++i)
-				nodeArray.push(tmp[i]);
-
-			const nodes = list.from(nodeArray);
-
-
-			// Find the node
-			const indices = list.fmap(pair.fst)(
-				list.filter(
-					p => pair.match(p)(
-						(i, v) => v > pos.treePos
-					), 
-					list.index(exprLengths)
-				)
-			);
-
-			const indexedNodes = list.zip(indices, nodes);
+			const targetNode = doc.querySelector(`[expos="${pos.exprPos}"][pos="${pos.treePos}"]`);
 
 			const atEnd = pos.exprPos >= len;
-			const node  = atEnd ? lastNode : list.lookup(pos.exprPos, indexedNodes);
-
+			const node  = atEnd ? lastNode : targetNode;
 
 			// Select the node
 			const range     = doc.createRange();
 			const selection = win.getSelection();
 
-			range.selectNode(node);
+			range.setStart(node, pos.offsetPos);
+			range.setEnd(node, pos.offsetPos);
 			selection.removeAllRanges();
 			selection.addRange(range);
 
@@ -117,9 +118,11 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 			const pos   = state.current().pos;
 			const exprs = state.current().exprs;
 
+			const newPos = list.length(exprs) === 0 ? 0 : pos.exprPos + 1;
+
 			const action = act.prod(
 				list.build(
-					act.assoc('pos', act.set(pos, createPos(pos.exprPos + 1, 0, 0))),
+					act.assoc('pos', act.set(pos, createPos(newPos, 0, 0))),
 					act.assoc('exprs', act.set(exprs, list.insert(pos.exprPos, e, exprs)))
 				)
 			);
@@ -181,7 +184,7 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 			const pos   = state.current().pos;
 			const exprs = state.current().exprs;
 			const len   = list.length(exprs);
-			const exprLengths = list.append(0, list.fmap(t => list.length(tree.polish(t)))(exprs));
+			const exprLengths = getExprLengths();
 
 			if (pos.treePos < list.at(pos.exprPos, exprLengths) - 1) {
 				setPosition(
@@ -190,7 +193,7 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 					pos.offsetPos
 				);
 			}
-			else if (pos.exprPos < len) {
+			else if (pos.exprPos < len - 1) {
 				setPosition(
 					pos.exprPos + 1,
 					0,
@@ -203,7 +206,7 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 			const pos   = state.current().pos;
 			const exprs = state.current().exprs;
 			const len   = list.length(exprs);
-			const exprLengths = list.append(0, list.fmap(t => list.length(tree.polish(t)))(exprs));
+			const exprLengths = getExprLengths();
 
 			if (pos.treePos > 0) {
 				setPosition(
@@ -229,15 +232,46 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 
 		// Rendering Methods
 
-		const render = () => {	
+		const render = () => {
 			const exprs = state.current().exprs;
 
 			if (list.isEmpty(exprs))
 				return startText.outerHTML;
 
+
+			const treePosLabeled = list.bind(
+				exprs,
+				e => list.produce(
+					expr.label.pos(tree.labels.addIf(	
+						expr.label.skip,
+						ev => expr.isOp(ev) && 
+							list.contains(
+								x => x == ev.value.symbol,
+								nontraversable
+							)
+					)(tree.labels.create(e)))
+				),
+			);
+
+			const exprPosLabeled = list.bind(
+				list.index(treePosLabeled),
+				p => pair.match(p)(
+					(i, e) => list.produce(
+						tree.labels.addIf(
+							tree.labels.build('expos', i), 
+							_ => true
+						)(
+						tree.labels.removeIf(
+							expr.label.skip,
+							_ => true
+						)
+						(e)))
+				)
+			);
+
 			const htmlTree = tree.node(
 				math,
-				list.fmap(mathML.markupLabeledExprTree)(list.fmap(expr.label.pos)(exprs))
+				list.fmap(mathML.markupLabeledExprTree)(exprPosLabeled)
 			);
 
 			return markup.renderTree(htmlTree);
@@ -254,6 +288,25 @@ function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse
 		container.onclick = (event) => {
 			event.preventDefault();	
 			container.focus();
+
+			const selection = win.getSelection();
+			const node      = selection.focusNode.parentNode;
+			const posAttr   = node.getAttribute('pos');
+			const exposAttr = node.getAttribute('expos');
+
+			container.innerHTML = render();
+
+			if (posAttr != null && exposAttr != null) {
+				const pos   = parseInt(posAttr);
+				const expos = parseInt(exposAttr);
+
+				if (selection.focusOffset === node.textContent.length)
+					setPosition(expos, pos + 1, 0);
+				else
+					setPosition(expos, pos, selection.focusOffset);
+
+				updateCursorPos();
+			}
 		}
 
 		container.onkeydown = (event) => {

--- a/scripts/richMathInput.js
+++ b/scripts/richMathInput.js
@@ -1,5 +1,5 @@
 
-function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win, doc) {
+function richMathInputLib(pair, list, tree, expr, history, markup, mathML, parse, win, doc) {
 
 // Character Utility
 	const isDigit = c => ('0' <= c && c <= '9');
@@ -10,13 +10,32 @@ function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win,
 	const act = history.actions;
 
 
+// Cursor Position
+	const createPos = (exprPos, treePos, offsetPos) => {
+		return Object.freeze({
+			__proto__: null,
+
+			exprPos:   exprPos,
+			treePos:   treePos,
+			offsetPos: offsetPos
+		});
+	};
+
+
 // Build An Input
 	const create = () => {
-		// Set up the internals
+		// Set up the elements
 		const container = doc.createElement('div');
 
 		container.classList.add('rich-math-input');
 		container.contentEditable = true;
+
+
+		const startText = doc.createElement('span');
+
+		startText.classList.add('rich-math-input-start-text');
+		startText.innerHTML = "type here...";
+
 
 		const math = markup.el(
 			"math",
@@ -27,55 +46,115 @@ function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win,
 		);
 
 
+		// Initialize the state
 		const state = history.create(
 			100,
 			{
 				__proto__: null,
 
-				pos:   0,
+				pos:   createPos(0, 0, 0),
 				exprs: list.nil
 			}
 		);
 
 
-		// Event Methods
 
-		const processDigit = c => {
+		// Cursor Position
+		const updateCursorPos = () => {
+			const pos   = state.current().pos;
+			const exprs = state.current().exprs;
+			const len   = list.length(exprs);
+			const exprLengths = list.append(0, list.fmap(t => list.length(tree.polish(t)))(exprs));
+
+			// Prepare the nodes
+			const allNodes = doc.querySelectorAll(`[pos]`);
+			const lastNode = allNodes[allNodes.length - 1];
+
+			if (allNodes.length === 0) return;
+
+			const tmp = doc.querySelectorAll(`[pos="${pos.treePos}"]`);
+			const nodeArray = [];
+
+			for (let i = 0; i < tmp.length; ++i)
+				nodeArray.push(tmp[i]);
+
+			const nodes = list.from(nodeArray);
+
+
+			// Find the node
+			const indices = list.fmap(pair.fst)(
+				list.filter(
+					p => pair.match(p)(
+						(i, v) => v > pos.treePos
+					), 
+					list.index(exprLengths)
+				)
+			);
+
+			const indexedNodes = list.zip(indices, nodes);
+
+			const atEnd = pos.exprPos >= len;
+			const node  = atEnd ? lastNode : list.lookup(pos.exprPos, indexedNodes);
+
+
+			// Select the node
+			const range     = doc.createRange();
+			const selection = win.getSelection();
+
+			range.selectNode(node);
+			selection.removeAllRanges();
+			selection.addRange(range);
+
+			if (atEnd)
+				selection.collapseToEnd();
+			else	
+				selection.collapseToStart();
+		};
+
+
+		// Event Methods
+		const insertExpr = e => {
+			const pos   = state.current().pos;
 			const exprs = state.current().exprs;
 
 			const action = act.prod(
 				list.build(
-					act.assoc('pos',   act.doNothing),
-					act.assoc('exprs', act.set(exprs, list.cons(expr.num(c), exprs)))
+					act.assoc('pos', act.set(pos, createPos(pos.exprPos + 1, 0, 0))),
+					act.assoc('exprs', act.set(exprs, list.insert(pos.exprPos, e, exprs)))
 				)
 			);
 
 			state.push(action);
 		}
 
-		const processAlpha = c => {
+		const setPosition = (exprPos, treePos, offsetPos) => {
+			const pos    = state.current().pos;
+			const newPos = createPos(exprPos, treePos, offsetPos);
 
+			const action = act.prod(
+				list.build(
+					act.assoc('pos',   act.set(pos, newPos)),
+					act.assoc('exprs', act.doNothing)
+				)
+			);
+
+			state.push(action);
 		}
+
+		const processDigit = c => insertExpr(expr.num(c));
+
+		const processAlpha = c => insertExpr(expr.ind(c));
+
 
 		const processNegative = () => {
 				
 		}
 
 		const processBinaryOp = op => {
-			const exprs = state.current().exprs;
+			const e = expr.lookupOp(op)(expr.placeholder(), expr.placeholder()); 
 
-			const e = expr.lookupOp(op)(expr.placeholder, expr.placeholder); 
-
-			if (e === undefined) return;
-
-			const action = act.prod(
-				list.build(
-					act.assoc('pos', act.doNothing),
-					act.assoc('exprs', act.set(exprs, list.cons(e, exprs)))
-				)
-			);
-
-			state.push(action);
+			if (e != undefined)
+				insertExpr(e);
 		}
 
 		const processOpenParen = () => {
@@ -99,11 +178,48 @@ function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win,
 		}
 
 		const processArrowRight = () => {
-		
+			const pos   = state.current().pos;
+			const exprs = state.current().exprs;
+			const len   = list.length(exprs);
+			const exprLengths = list.append(0, list.fmap(t => list.length(tree.polish(t)))(exprs));
+
+			if (pos.treePos < list.at(pos.exprPos, exprLengths) - 1) {
+				setPosition(
+					pos.exprPos, 
+					pos.treePos + 1, 
+					pos.offsetPos
+				);
+			}
+			else if (pos.exprPos < len) {
+				setPosition(
+					pos.exprPos + 1,
+					0,
+					0
+				);
+			}
 		}
 
 		const processArrowLeft = () => {
-		
+			const pos   = state.current().pos;
+			const exprs = state.current().exprs;
+			const len   = list.length(exprs);
+			const exprLengths = list.append(0, list.fmap(t => list.length(tree.polish(t)))(exprs));
+
+			if (pos.treePos > 0) {
+				setPosition(
+					pos.exprPos,
+					pos.treePos - 1,
+					pos.offsetPos
+				);
+			}
+			else if (pos.exprPos > 0) {
+				setPosition(
+					pos.exprPos - 1,
+					list.at(pos.exprPos - 1, exprLengths) - 1,
+					pos.offsetPos
+				);		
+			}
+
 		}
 
 		const processTab = () => {
@@ -116,15 +232,21 @@ function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win,
 		const render = () => {	
 			const exprs = state.current().exprs;
 
+			if (list.isEmpty(exprs))
+				return startText.outerHTML;
+
 			const htmlTree = tree.node(
 				math,
-				list.fmap(mathML.markupExprTree)(list.reverse(exprs))
+				list.fmap(mathML.markupLabeledExprTree)(list.fmap(expr.label.pos)(exprs))
 			);
 
 			return markup.renderTree(htmlTree);
 		}
 
-		const get = () => container;
+		const get = () => {
+			container.innerHTML = render();
+			return container;
+		}
 
 
 		// Initialize Handlers
@@ -183,6 +305,9 @@ function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win,
 						case ')':
 							processCloseParen();
 							break;
+
+						default:
+							return;
 					}
 
 					needsToUpdate = true;
@@ -215,11 +340,16 @@ function richMathInputLib(list, tree, expr, history, markup, mathML, parse, win,
 					case 'ArrowRight':
 						processArrowRight();
 						break;
+
+					default:
+						return;
 				}
 			}
 
 			if (needsToUpdate)
 				container.innerHTML = render();
+
+			updateCursorPos();
 		};
 
 

--- a/scripts/tree.js
+++ b/scripts/tree.js
@@ -30,9 +30,16 @@ function treeLib(list) {
 	const fmap = f => foldr(v => leaf(f(v)), (v, c) => node(f(v), c));
 
 	
-// Tree Processing
-	const depthFirstPolish        = foldr(list.produce, (v, c) => list.cons(v, list.join(c)));	
-	const depthFirstReversePolish = foldr(list.produce, (v, c) => list.append(v, list.join(c)));
+// Traversal
+	const depthFirstPolish = foldr(
+		list.produce, 
+		(v, c) => list.cons(v, list.join(c))
+	);
+
+	const depthFirstReversePolish = foldr(
+		list.produce, 
+		(v, c) => list.append(v, list.join(c))
+	);
 
 
 // String Diagram
@@ -84,7 +91,7 @@ function treeLib(list) {
 	};
 
 
-
+// Library
 	return Object.freeze({
 		__proto__: null,
 

--- a/scripts/tree.js
+++ b/scripts/tree.js
@@ -43,14 +43,14 @@ function treeLib(pair, list) {
 // Aux
 	const labeledTree = fmap(v => pair.build(v, list.nil));
 
-	const addLabelIf = (cond, tag) => fmap(p => pair.match(p)(
+	const addLabelIf = (tag, cond) => fmap(p => pair.match(p)(
 		(v, tags) => pair.build(
 			v, 
 			cond(v) ? list.cons(tag, tags) : tags
 		)
 	));
 
-	const addLabel = (value, tag) => labelIf(v => v === value);
+	const addLabel = (tag, value) => labelIf(v => v === value);
 
 	const removeLabelsIf = (cond) => fmap(p => pair.match(p)(
 		(v, tags) => pair.build(
@@ -59,21 +59,20 @@ function treeLib(pair, list) {
 		)
 	));
 
-	const removeLabelIf = (cond, tag) => fmap(p => pair.match(p)(
+	const removeLabelIf = (tag, cond) => fmap(p => pair.match(p)(
 		(v, tags) => pair.build(
 			v,
 			cond(v) ? list.filter(x => x !== tag)(tags) : tags
 		)
 	));
 
-	const removeLabel  = (value, tag) => removeLabelIf(v => v === value, tag);
+	const removeLabel  = (tag, value) => removeLabelIf(v => v === value, tag);
 
-	const removeLabels = (value, tag) => removeLabelsIf(v => v === value, tag);
+	const removeLabels = (tag, value) => removeLabelsIf(v => v === value, tag);
 
 
 
 // String Diagram
-
 	const markTerminals = foldr(
 		v       => leaf(pair.build(v, false)),
 		(v, cs) => node(

--- a/scripts/tree.js
+++ b/scripts/tree.js
@@ -50,7 +50,7 @@ function treeLib(pair, list) {
 		)
 	));
 
-	const addLabel = (tag, value) => labelIf(v => v === value);
+	const addLabel = (tag, value) => addLabelIf(tag, v => v === value);
 
 	const removeLabelsIf = (cond) => fmap(p => pair.match(p)(
 		(v, tags) => pair.build(
@@ -66,9 +66,11 @@ function treeLib(pair, list) {
 		)
 	));
 
-	const removeLabel  = (tag, value) => removeLabelIf(v => v === value, tag);
+	const removeLabel  = (tag, value) => removeLabelIf(tag, v => v === value);
 
-	const removeLabels = (tag, value) => removeLabelsIf(v => v === value, tag);
+	const removeLabels = (tag, value) => removeLabelsIf(tag, v => v === value);
+
+	const stripLabels = removeLabelsIf(x => true);
 
 
 
@@ -142,10 +144,13 @@ function treeLib(pair, list) {
 
 			addIf:       addLabelIf,
 			add:         addLabel,
+
 			removeAllIf: removeLabelsIf,
 			removeAll:   removeLabels,
 			removeIf:    removeLabelIf,
-			remove:      removeLabel
+			remove:      removeLabel,
+
+			strip:       stripLabels
 		}),
 
 		diagram:  treeDiagram,

--- a/scripts/tree.js
+++ b/scripts/tree.js
@@ -41,6 +41,13 @@ function treeLib(pair, list) {
 
 
 // Aux
+	const buildLabel = (name, value) => Object.freeze({
+		__proto__: null,
+
+		name: name,
+		value: value
+	});
+
 	const labeledTree = fmap(v => pair.build(v, list.nil));
 
 	const addLabelIf = (tag, cond) => fmap(p => pair.match(p)(
@@ -71,6 +78,10 @@ function treeLib(pair, list) {
 	const removeLabels = (tag, value) => removeLabelsIf(tag, v => v === value);
 
 	const stripLabels = removeLabelsIf(x => true);
+
+	const getLabels = pair.snd;
+
+	const getValue = pair.fst;
 
 
 
@@ -140,6 +151,8 @@ function treeLib(pair, list) {
 		labels: Object.freeze({
 			__proto__: null,
 
+			build:       buildLabel,
+
 			create:      labeledTree,
 
 			addIf:       addLabelIf,
@@ -150,7 +163,10 @@ function treeLib(pair, list) {
 			removeIf:    removeLabelIf,
 			remove:      removeLabel,
 
-			strip:       stripLabels
+			strip:       stripLabels,
+
+			getValue:    getValue,
+			getLabels:   getLabels
 		}),
 
 		diagram:  treeDiagram,

--- a/scripts/tree.js
+++ b/scripts/tree.js
@@ -1,4 +1,4 @@
-function treeLib(list) {
+function treeLib(pair, list) {
 
 // Trees
 	const node = (value, children) => {
@@ -18,14 +18,12 @@ function treeLib(list) {
 
 	const children = tree => tree.children; 
 
-	function foldr(onLeaf, onBranch) {
-		return tree => {
-			if (isLeaf(tree))
-				return onLeaf(tree.value);
-			else
-				return onBranch(tree.value, list.fmap(foldr(onLeaf, onBranch))(tree.children));
-		};
-	}
+	const foldr = (onLeaf, onBranch) => tree => {
+		if (isLeaf(tree))
+			return onLeaf(tree.value);
+		else
+			return onBranch(tree.value, list.fmap(foldr(onLeaf, onBranch))(tree.children));
+	};
 
 	const fmap = f => foldr(v => leaf(f(v)), (v, c) => node(f(v), c));
 
@@ -42,35 +40,65 @@ function treeLib(list) {
 	);
 
 
+// Aux
+	const labeledTree = fmap(v => pair.build(v, list.nil));
+
+	const addLabelIf = (cond, tag) => fmap(p => pair.match(p)(
+		(v, tags) => pair.build(
+			v, 
+			cond(v) ? list.cons(tag, tags) : tags
+		)
+	));
+
+	const addLabel = (value, tag) => labelIf(v => v === value);
+
+	const removeLabelsIf = (cond) => fmap(p => pair.match(p)(
+		(v, tags) => pair.build(
+			v, 
+			cond(v) ? list.nil : tags
+		)
+	));
+
+	const removeLabelIf = (cond, tag) => fmap(p => pair.match(p)(
+		(v, tags) => pair.build(
+			v,
+			cond(v) ? list.filter(x => x !== tag)(tags) : tags
+		)
+	));
+
+	const removeLabel  = (value, tag) => removeLabelIf(v => v === value, tag);
+
+	const removeLabels = (value, tag) => removeLabelsIf(v => v === value, tag);
+
+
+
 // String Diagram
-	const pair = (fst, snd) => {
-		return {
-			__proto__: null,
-			
-			fst: fst,
-			snd: snd
-		};
-	};
 
 	const markTerminals = foldr(
-		v => leaf(pair(v, false)),
-		(v, cs) => node(pair(v, false), list.append(node(pair(list.last(cs).value.fst, true), list.last(cs).children), list.init(cs)))
+		v       => leaf(pair.build(v, false)),
+		(v, cs) => node(
+			pair.build(v, false), 
+			list.append(
+				node(pair.build(
+					pair.fst(list.last(cs).value), true), 
+					list.last(cs).children), 
+				list.init(cs)))
 	);
 
 	const pipeCodes = tree => fmap(b => b ? '\u2514' : '\u251C')(markTerminals(tree));
 
 	const subTreeDiagram = tree => 
 		foldr(
-			p => list.build((p.snd ? '\u2514' : '\u251C') + ' ' + p.fst),
+			p => list.build((pair.snd(p) ? '\u2514' : '\u251C') + ' ' + pair.fst(p)),
 			(p, cs) => {
-				if (p.snd)
-					return list.cons('\u2514' + ' ' + p.fst, list.fmap(q => '  ' + q)(list.join(cs)));
+				if (pair.snd(p))
+					return list.cons('\u2514' + ' ' + pair.fst(p), list.fmap(q => '  ' + q)(list.join(cs)));
 				else
-					return list.cons('\u251C' + ' ' + p.fst, list.fmap(q => '\u2502' + ' ' + q)(list.join(cs)));
+					return list.cons('\u251C' + ' ' + pair.fst(p), list.fmap(q => '\u2502' + ' ' + q)(list.join(cs)));
 			}
 		)(markTerminals(tree));
 
-	function treeDiagram(tree) {
+	const treeDiagram = (tree) => {
 		const front = '\u2514' + ' ' + tree.value;
 
 		if (isLeaf(tree))
@@ -83,7 +111,7 @@ function treeLib(list) {
 					treeDiagram(list.last(tree.children))
 				)))
 			);
-	}
+	};
 
 	
 	const print = (tree, acceptor) => {
@@ -107,6 +135,19 @@ function treeLib(list) {
 
 		polish:   depthFirstPolish,
 		rPolish:  depthFirstReversePolish,
+
+		labels: Object.freeze({
+			__proto__: null,
+
+			create:      labeledTree,
+
+			addIf:       addLabelIf,
+			add:         addLabel,
+			removeAllIf: removeLabelsIf,
+			removeAll:   removeLabels,
+			removeIf:    removeLabelIf,
+			remove:      removeLabel
+		}),
 
 		diagram:  treeDiagram,
 

--- a/scripts/tree.js
+++ b/scripts/tree.js
@@ -69,7 +69,7 @@ function treeLib(pair, list) {
 	const removeLabelIf = (tag, cond) => fmap(p => pair.match(p)(
 		(v, tags) => pair.build(
 			v,
-			cond(v) ? list.filter(x => x !== tag)(tags) : tags
+			cond(v) ? list.filter(x => x !== tag, tags) : tags
 		)
 	));
 


### PR DESCRIPTION
- Implements element traversal in the rich math input library.
  - Modifies cursor position tracking to include the expression position, tree position, and offset position.
  - Adds placeholder text to the input.
  - Adds `getExprLengths`, `updateCursorPos`, `insertExpr`, and `setPosition` functions.
  - Implements `processArrowLeft` and `processArrowRight`.
- Adds tree labeling functions to the tree library.
- Adds expression rendering, traversal, and the function `isOperator`.
- Adds `generate`, `take`, `drop`, `at`, `insert`, `index`, and `contains` to the list library.
- Modifies the MathML library function `markupExprTree` to insert tree labels as markup attributes.
- Updates the markup library to respect updates to the parse library.

Note: _Offsets are not yet entirely implemented._